### PR TITLE
Render command support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,6 @@ release: clean test
 
 upload:
 	python setup.py clean sdist upload
+
+build:
+	@go build -o bin/kubecd ./cmd/kcd

--- a/cmd/kcd/render.go
+++ b/cmd/kcd/render.go
@@ -1,0 +1,85 @@
+/*
+Copyright © 2019 Zedge, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/zedge/kubecd/pkg/helm"
+	"github.com/zedge/kubecd/pkg/model"
+)
+
+var pipeFriendly bool
+
+
+var renderCmd = &cobra.Command{
+	Use:   "render",
+	Short: "show helm templates and plain kubernetes YAML resources",
+	Long:  ``,
+	Args:  clusterFlagOrEnvArg(&applyCluster),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		kcdConfig, err := model.NewConfigFromFile(environmentsFile)
+		if err != nil {
+			return err
+		}
+		envsToApply, err := environmentsToApply(kcdConfig, args)
+		if err != nil {
+			return err
+		}
+		commandsToRun, err := commandsToRender(envsToApply)
+		if err != nil {
+			return err
+		}
+		for _, argv := range commandsToRun {
+			if err = runCommand(applyDryRun, argv); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func commandsToRender(envsToApply []*model.Environment) ([][]string, error) {
+	commandsToRun := make([][]string, 0)
+	for _, env := range envsToApply {
+		if applyInit {
+			initCmds, err := commandsToInit(envsToApply, applyGitlab)
+			if err != nil {
+				return nil, err
+			}
+			for _, cmd := range initCmds {
+				commandsToRun = append(commandsToRun, cmd)
+			}
+		}
+		deployCmds, err := helm.TemplateCommands(env, applyReleases)
+		if err != nil {
+			return nil, err
+		}
+		for _, cmd := range deployCmds {
+			commandsToRun = append(commandsToRun, cmd)
+		}
+	}
+	return commandsToRun, nil
+}
+
+
+func init() {
+	rootCmd.AddCommand(renderCmd)
+	renderCmd.Flags().BoolVar(&pipeFriendly, "pipe", false, "Make output pipe friendly for kubeval")
+	renderCmd.Flags().StringSliceVarP(&applyReleases, "releases", "r", []string{}, "generate template only these releases")
+	renderCmd.Flags().StringVarP(&applyCluster, "cluster", "c", "", "template all environments in CLUSTER")
+	renderCmd.Flags().BoolVar(&applyInit, "init", false, "initialize credentials and contexts")
+	renderCmd.Flags().BoolVar(&applyGitlab, "gitlab", false, "initialize in gitlab mode")
+}

--- a/cmd/kcd/root.go
+++ b/cmd/kcd/root.go
@@ -108,7 +108,11 @@ func initConfig() {
 
 func runCommand(dryRun bool, argv []string) error {
 	printCmd := strings.Join(argv, " ")
-	_, _ = colorstring.Printf("[yellow]%s\n", printCmd)
+
+	if !pipeFriendly {
+		_, _ = colorstring.Printf("[yellow]%s\n", printCmd)
+	}
+
 	if !dryRun {
 		cmd := exec.Command(argv[0], argv[1:]...)
 		cmd.Stdout = os.Stdout

--- a/pkg/model/helm.go
+++ b/pkg/model/helm.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"encoding/json"
-	"strconv"
+	"github.com/ghodss/yaml"
 )
 
 type ChartValueRef struct {
@@ -33,17 +33,16 @@ type HelmRepo struct {
 }
 
 func (is *FlexString) UnmarshalJSON(data []byte) error {
-	if string(data) == "true" || string(data) == "false" {
-		data = []byte(`"` + string(data) + `"`)
-	}
 	if data[0] == '"' {
 		return json.Unmarshal(data, (*string)(is))
 	}
-	var i int
-	if err := json.Unmarshal(data, &i); err != nil {
+
+	data2, err := yaml.YAMLToJSON(data)
+	if err != nil {
 		return err
 	}
-	*is = FlexString(strconv.Itoa(i))
+
+	*is = FlexString(data2)
 	return nil
 }
 


### PR DESCRIPTION
Feature: Support `kcd render` which runs either `helm template ...` or `cat kubernetes-resource.yaml` with YAML document dividers added.

Useful for piping into `kubeval` for linting. 